### PR TITLE
Fix reference line number in namespaces.cpp

### DIFF
--- a/src/namespaces.cpp
+++ b/src/namespaces.cpp
@@ -22,7 +22,7 @@
 
 // This is the syntax to declare a namespace.
 namespace ABC {
-  // We define a function spam in the ABC namespace. This is used in line 44.
+  // We define a function spam in the ABC namespace. This is used in line 57.
   void spam(int a) {
     std::cout << "Hello from ABC::spam: " << a << std::endl;
   }


### PR DESCRIPTION
In this comment, the function is used in line 57 rather than 44.
https://github.com/cmu-db/15445-bootcamp/blob/26e080ae8dda27b2dd5bdf626e63e479b4ada398/src/namespaces.cpp#L25

btw thanks for these clear introductions!