### PR TITLE
fix: return a reference to the DLLIterator when overloading a pre-increment operator

### DIFF
--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -60,7 +60,7 @@ class DLLIterator {
       : curr_(head) {}
 
     // Implementing a prefix increment operator (++iter).
-    DLLIterator operator++() {
+    DLLIterator& operator++() {
       curr_ = curr_->next_;
       return *this;
     }


### PR DESCRIPTION
I notice that DLLIterator overloads the pre-increment operator without returning a reference.

Although there is a [post](https://stackoverflow.com/questions/6375697/do-i-have-to-return-a-reference-to-the-object-when-overloading-a-pre-increment-o) here that says this is not necessary, common implementation will return a reference when overloading a pre-increment operator, which is also mentioned in [cppreference](https://en.cppreference.com/w/cpp/language/operator_incdec).

BTW I'm OK if you ignore this PR and just make the edits yourself as you see fit.

Finally, thank you for putting together this repo. I think many will find it helpful.