### PR TITLE
fix unintended copying

### DIFF
--- a/src/unordered_maps.cpp
+++ b/src/unordered_maps.cpp
@@ -114,7 +114,7 @@ int main() {
   // Just like std::vector, we can also iterate through the unordered map
   // via a for-each loop.
   std::cout << "Printing the elements of the iterator with a for-each loop:\n";
-  for (const std::pair<std::string, int> &elem : map) {
+  for (const std::pair<const std::string, int> &elem : map) {
     std::cout << "(" << elem.first << ", " << elem.second << "), ";
   }
   std::cout << "\n";

--- a/src/vectors.cpp
+++ b/src/vectors.cpp
@@ -114,7 +114,7 @@ int main() {
   // in the vector. The vector iterator also has a plus operator that takes
   // a vector iterator and an integer. The plus operator will increase the 
   // index of the element that the iterator is pointing to by the number passed
-  // in. Therefore, int_vector.begin() + 2 is pointing to the second element in
+  // in. Therefore, int_vector.begin() + 2 is pointing to the third element in
   // the vector, or the element at int_vector[2].
   // If you are confused about iterators, it may be helpful to read the header of
   // iterator.cpp.


### PR DESCRIPTION
When using `range-based for loop` on `unordered_map`, the named variable should have a type like `std::pair<const Key, Value>`. If we ignore the `const`, this will cause some unnecessary copying.

Maybe we can show the usage of `auto` and `structured binding` here.

https://godbolt.org/z/GsM6eYWMa