### PR TITLE
[fix]fix CMakeLists.txt to set output directory for executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+# Avoid name clash with the C++ standard header <mutex> by placing executables in a subdir.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
 # Compiling move semantics/references executables
 add_executable(references src/references.cpp)
 add_executable(move_semantics src/move_semantics.cpp)


### PR DESCRIPTION
set CMakeLists.txt output directory for executables "build/bin". It can avoid the compilation error:
"source file is not valid UTF-8".